### PR TITLE
Update RuntimeCallHandler.php

### DIFF
--- a/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
+++ b/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php
@@ -133,7 +133,7 @@ final class RuntimeCallHandler implements CallHandler
      */
     private function stopErrorAndOutputBuffering()
     {
-        ob_end_clean();
+        if (ob_get_length()) ob_end_clean();
         restore_error_handler();
     }
 }


### PR DESCRIPTION
I'm getting a notice `Notice: ob_end_clean(): failed to delete buffer. No buffer to delete in vendor/behat/behat/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php line 137` which is really weird because the method is only called from `handleCall`, maybe its a PHP bug. This solves the notice.
